### PR TITLE
ユーザー名の認証方法を変更

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -44,4 +44,9 @@ class AuthenticatedSessionController extends Controller
 
         return redirect('/');
     }
+
+    public function username(): string
+    {
+        return 'username';
+    }
 }

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -27,7 +27,7 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => ['required', 'string', 'email'],
+            'username' => ['required', 'string'],
             'password' => ['required', 'string'],
         ];
     }

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -39,17 +39,18 @@ class LoginRequest extends FormRequest
      */
     public function authenticate(): void
     {
-        $this->ensureIsNotRateLimited();
+        $this->ensureIsNotRateLimited(); // ログイン試行がレートリミットに達していないことを確認します。
 
-        if (! Auth::attempt($this->only('email', 'password'), $this->boolean('remember'))) {
-            RateLimiter::hit($this->throttleKey());
+        // ユーザー名とパスワードで認証を試みます。`remember`オプションがtrueの場合、セッションを永続化します。
+        if (! Auth::attempt($this->only('username', 'password'), $this->boolean('remember'))) {
+            RateLimiter::hit($this->throttleKey()); // 認証に失敗した場合、レートリミットカウンターを増やします。
 
+             // 認証に失敗したことをユーザーに通知します。エラーメッセージは`username`フィールドに関連付けられます。
             throw ValidationException::withMessages([
                 'email' => trans('auth.failed'),
             ]);
         }
-
-        RateLimiter::clear($this->throttleKey());
+        RateLimiter::clear($this->throttleKey()); // 認証に成功した場合、レートリミットカウンターをリセットします。
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -20,6 +20,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'username',
     ];
 
     /**
@@ -43,15 +44,5 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
-    }
-
-    /**
- * Get the name of the unique identifier for the user.
- *
- * @return string
- */
-    public function getAuthIdentifierName()
-    {
-        return 'username';
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -44,4 +44,14 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    /**
+ * Get the name of the unique identifier for the user.
+ *
+ * @return string
+ */
+    public function getAuthIdentifierName()
+    {
+        return 'username';
+    }
 }

--- a/database/migrations/2024_03_25_085454_add_username_to_users_table.php
+++ b/database/migrations/2024_03_25_085454_add_username_to_users_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            //
+            $table->dropColumn('username');
         });
     }
 };

--- a/database/migrations/2024_03_25_085454_add_username_to_users_table.php
+++ b/database/migrations/2024_03_25_085454_add_username_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('username')->unique()->after('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -5,11 +5,11 @@
     <form method="POST" action="{{ route('login') }}">
         @csrf
 
-        <!-- Email Address -->
+        <!-- user name -->
         <div>
-            <x-input-label for="email" :value="__('Email')" />
-            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus autocomplete="username" />
-            <x-input-error :messages="$errors->get('email')" class="mt-2" />
+            <x-input-label for="username" :value="__('Username')" />
+            <x-text-input id="username" class="block mt-1 w-full" type="text" name="username" :value="old('username')" required autofocus autocomplete="username" />
+            <x-input-error :messages="$errors->get('username')" class="mt-2" />
         </div>
 
         <!-- Password -->

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -8,7 +8,8 @@
         <!-- user name -->
         <div>
             <x-input-label for="username" :value="__('Username')" />
-            <x-text-input id="username" class="block mt-1 w-full" type="text" name="username" :value="old('username')" required autofocus autocomplete="username" />
+            <x-text-input id="username" class="block mt-1 w-full" type="text" name="username" :value="old('username')" required
+                autofocus autocomplete="username" />
             <x-input-error :messages="$errors->get('username')" class="mt-2" />
         </div>
 
@@ -16,10 +17,8 @@
         <div class="mt-4">
             <x-input-label for="password" :value="__('Password')" />
 
-            <x-text-input id="password" class="block mt-1 w-full"
-                            type="password"
-                            name="password"
-                            required autocomplete="current-password" />
+            <x-text-input id="password" class="block mt-1 w-full" type="password" name="password" required
+                autocomplete="current-password" />
 
             <x-input-error :messages="$errors->get('password')" class="mt-2" />
         </div>
@@ -27,14 +26,16 @@
         <!-- Remember Me -->
         <div class="block mt-4">
             <label for="remember_me" class="inline-flex items-center">
-                <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" name="remember">
+                <input id="remember_me" type="checkbox"
+                    class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" name="remember">
                 <span class="ms-2 text-sm text-gray-600">{{ __('Remember me') }}</span>
             </label>
         </div>
 
         <div class="flex items-center justify-end mt-4">
             @if (Route::has('password.request'))
-                <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('password.request') }}">
+                <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                    href="{{ route('password.request') }}">
                     {{ __('Forgot your password?') }}
                 </a>
             @endif


### PR DESCRIPTION
## 目的
認証プロセスを改善し、ユーザー名に基づく認証に移行することを目的としています。この変更を通じて、導入企業のスタッフがより容易にログインできるようになることを目指しています。具体的には、従業員が自身のユーザー名を使用することで、メールアドレスに依存する従来の方法に比べて、ログインプロセスをより直感的かつ迅速に行えるようにすることが狙いです。

## 達成条件
ユーザー認証がユーザー名とパスワードを用いた方法に変更されること。
認証成功時および失敗時のレートリミットの管理が適切に行われること。

## 実装の概要
authenticateメソッド内で、認証プロセスを「email」と「password」から「username」と「password」へと変更しました。
認証失敗時にレートリミットカウンターを増加させ、成功時にはこれをリセットするようにしました。
認証失敗時のエラーメッセージをusernameフィールドに関連付けるよう変更しました。
HTMLテンプレート内でユーザー名入力フィールドのマークアップを微調整しました。

## レビューしてほしいところ
認証プロセスの変更がセキュリティやパフォーマンスに悪影響を与えていないか、特に注目してレビューしていただきたいです。

## 不安に思っていること
ユーザー名に基づく認証への変更が、既存のユーザー体験にどのような影響を与えるかが気になっています。

## 保留していること
UI/UXの改善に関する追加作業は、別途計画しています。