### PR TITLE
ユーザーテーブルシーダーに管理者ユーザーを追加

### DIFF
--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+class UsersTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('users')->insert([
+            'username' => 'admin',
+            'name' => '管理者',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('adminpassword'),
+            'email_verified_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
アプリケーションの初期セットアップ時に管理者ユーザーが必要であるため、
UsersTableSeederに管理者アカウントのデフォルトデータを追加しました。
これにより、新しい環境をセットアップする際に手動で管理者ユーザーを作成する必要がなくなります。