### PR TITLE
 ログイン後のリダイレクト先をダッシュボードからインデックスページに変更

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -28,7 +28,7 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
-        return redirect()->intended(route('dashboard', absolute: false));
+        return redirect()->intended(route('index'));
     }
 
     /**

--- a/resources/views/components/auth-links.blade.php
+++ b/resources/views/components/auth-links.blade.php
@@ -18,5 +18,4 @@
             @endif --}}
         @endauth
     </nav>
-
 @endif


### PR DESCRIPTION
## 目的

ログイン後のリダイレクト先をダッシュボードページからインデックスページに変更することで、ユーザーがより迅速にメインコンテンツへアクセスできるようにすることを目指します。これにより、ユーザーエクスペリエンスの向上を図ります。

## 達成条件

- ユーザーがログイン後、ダッシュボードではなくインデックスページに直接リダイレクトされること。
- 既存のリダイレクト機能に影響を与えずに、指定したページへのリダイレクトが正常に機能すること。

## 実装の概要

`AuthController`内で、ログイン後のリダイレクト先を`dashboard`から`index`に変更しました。これにより、ユーザーはログイン直後に投稿一覧ページへアクセスできるようになります。

## レビューしてほしいところ

特に、リダイレクト処理の変更点において、予期せぬ副作用が発生していないかを中心にレビューしていただきたいです。また、命名規則に従っているか、より適切なメソッドの使用があるかについてのフィードバックも歓迎します。

## 不安に思っていること

リダイレクトの変更により、特定のユースケースでユーザーが予期せぬ挙動に直面する可能性があります。特に、セッションの扱いに関して、問題がないか確認していただきたいです。

## 保留していること

現段階では、インデックスページにリダイレクト後にブラウザの戻るボタンを押すと、ダッシュボードにページ遷移してしまう問題が起きます。この問題に関しては、追加のフィードバックを得た上で、将来的に検討する予定です。