### PR TITLE
コメント機能の実装とUIの改善

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -28,7 +28,11 @@ class CommentController extends Controller
      */
     public function store(Request $request)
     {
-        //
+        $comments = new Comment();
+        $form = $request->all();
+        $form['user_id'] = $request->user()->id;
+        $comments->fill($form)->save();
+        return redirect('/index');
     }
 
     /**

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -9,6 +9,12 @@ class Comment extends Model
 {
     use HasFactory;
 
+    protected $fillable = [
+        'post_id',
+        'user_id',
+        'message',
+    ];
+
     public function user()
     {
         return $this->belongsTo(User::class, 'user_id');

--- a/database/migrations/2024_04_07_072305_remove_field_from_comments_table.php
+++ b/database/migrations/2024_04_07_072305_remove_field_from_comments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->dropColumn('parent_comment_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->bigInteger('parent_comment_id')->unsigned()->nullable();
+        });
+    }
+};

--- a/resources/views/layouts/index.blade.php
+++ b/resources/views/layouts/index.blade.php
@@ -4,24 +4,23 @@
         <h1 class="text-xl font-bold mt-5">{{ env('app_name') }}</h1>
 
         {{-- 入力フォーム --}}
-            <div class="bg-white rounded-md mt-5 p-3">
-                <form action="{{ route('posts.store') }}" method="POST">
-                    @csrf
-                    <div class="flex mt-2">
-                        <p class="font-bold">件名</p>
-                        <input class="border rounded px-2 ml-2 flex-auto" type="text" name="title" required>
-                    </div>
-                    <div class="flex flex-col mt-2">
-                        <p class="font-bold">本文</p>
-                        <textarea class="border rounded px-2" name="message" required></textarea>
-                    </div>
-                    <div class="flex justify-end mt-2">
-                        <input
-                            class="my-2 px-2 py-1 rounded bg-blue-300 text-blue-900 font-bold link-hover cursor-pointer"
-                            type="submit" value="投稿">
-                    </div>
-                </form>
-            </div>
+        <div class="bg-white rounded-md mt-5 p-3">
+            <form action="{{ route('posts.store') }}" method="POST">
+                @csrf
+                <div class="flex mt-2">
+                    <p class="font-bold">件名</p>
+                    <input class="border rounded px-2 ml-2 flex-auto" type="text" name="title" required>
+                </div>
+                <div class="flex flex-col mt-2">
+                    <p class="font-bold">本文</p>
+                    <textarea class="border rounded px-2" name="message" required></textarea>
+                </div>
+                <div class="flex justify-end mt-2">
+                    <input class="my-2 px-2 py-1 rounded bg-blue-300 text-blue-900 font-bold link-hover cursor-pointer"
+                        type="submit" value="投稿">
+                </div>
+            </form>
+        </div>
         {{-- 検索フォーム --}}
         <div class="bg-white rounded-md mt-3 p-3">
             <form action="/" method="post">
@@ -47,13 +46,17 @@
                     <p class="mb-2">{{ $post->message }}</p>
                 </div>
                 {{-- 削除ボタン --}}
-                <form class="flex justify-end mt-5" action="/" method="POST">
+                {{-- <form class="flex justify-end mt-5" action="/" method="POST"> --}}
+                <form class="flex justify-end mt-5" action="{{ route('comment.store') }}" method="POST">
                     @csrf
-                    <input class="border rounded px-2 flex-auto" type="text" name="reply_message">
+                    <input type="hidden" name="post_id" value="{{ $post->id }}">
+                    {{-- <input class="border rounded px-2 flex-auto" type="text" name="reply_message"> --}}
+                    {{-- <input class="border rounded px-2 flex-initial" type="text" name="user_name" placeholder="UserName" required> --}}
+                    <input class="border rounded px-2 ml-2 flex-auto" type="text" name="message" placeholder="Comment" required>
                     <input class="px-2 py-1 ml-2 rounded bg-green-600 text-white font-bold link-hover cursor-pointer"
                         type="submit" value="返信">
                     <input class="px-2 py-1 ml-2 rounded bg-red-500 text-white font-bold link-hover cursor-pointer"
-                        type="submit" value="削除">
+                        type="button" value="削除">
                 </form>
                 {{-- 返信 --}}
                 <hr class="mt-2 m-auto">

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,8 @@ Route::get('/index', [PostController::class, 'index'])
 Route::post('/posts', [PostController::class, 'store'])
     ->name('posts.store');
 
+Route::resource('/comment', CommentController::class);
+
 Route::get('/dashboard', function () {
     return view('dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');


### PR DESCRIPTION
# コメント機能の改善とUIの更新

## 目的

このプルリクエストでは、コメント機能の改善とユーザーインターフェイスの更新を目的としています。具体的には、コメントの階層構造をサポートする`parent_comment_id`カラムの削除と、入力フォームのスタイルのリフレッシュを行います。

## 達成条件

- `comments`テーブルから`parent_comment_id`カラムが正常に削除されること。
- 入力フォームのスタイルが更新され、ユーザーにとってより使いやすくなっていること。
- コメント投稿機能が正常に動作すること。

## 実装の概要

- `up`メソッド内で、`comments`テーブルのマイグレーションを実行し、`parent_comment_id`カラムを削除しました。理由としては、テストを実施した結果、コメントに対する返信機能よりも、単一の投稿に対するコメントの追加で十分なコミュニケーションが行えると感じたためです。

- コメント投稿フォームのHTML構造はそのままに、スタイリングを更新しました。
- `CommentController`の`store`メソッドを更新し、コメント投稿機能を実装しました。

## レビューしてほしいところ

- マイグレーションの実装が適切かどうか。
- UIの更新が指定のデザインガイドラインに沿っているかどうか。
- コメント投稿機能のロジックに潜在的な問題がないか。

## 不安に思っていること

- マイグレーションを実行する際の既存データへの影響。
- UIの更新がすべてのブラウザで期待通りに表示されるかどうか。

## 保留していること

- レスポンシブデザインの詳細な調整は、フィードバックを受けてから追加で行う予定です。