### PR TITLE
投稿の削除機能の追加

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -70,6 +70,8 @@ class PostController extends Controller
      */
     public function destroy(string $id)
     {
-        //
+        // スレッド情報をデータベースから削除
+       $Post = Post::find($id)->delete();
+       return redirect('/index');
     }
 }

--- a/database/migrations/2024_04_07_082516_add_on_delete_cascade_to_comments_table.php
+++ b/database/migrations/2024_04_07_082516_add_on_delete_cascade_to_comments_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+             // 既存の外部キー制約を削除
+             $table->dropForeign(['post_id']);
+             // 新しい外部キー制約を追加
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            // 追加した外部キー制約を削除
+            $table->dropForeign(['post_id']);
+            // 元の外部キー制約を復元
+            $table->foreign('post_id')->references('id')->on('posts');
+        });
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,5 @@
 import './bootstrap';
+import './delete';
 
 import Alpine from 'alpinejs';
 

--- a/resources/js/delete.js
+++ b/resources/js/delete.js
@@ -1,0 +1,10 @@
+function Check(event) {
+    const checked = confirm("本当に削除しますか？");
+    if (checked == true) {
+        return true;
+    } else {
+        event.preventDefault();
+        return false;
+    }
+}
+window.Check = Check;

--- a/resources/views/layouts/index.blade.php
+++ b/resources/views/layouts/index.blade.php
@@ -45,19 +45,26 @@
                     <p class="mb-2 text-xl font-bold">{{ $post->title }}</p>
                     <p class="mb-2">{{ $post->message }}</p>
                 </div>
-                {{-- 削除ボタン --}}
-                {{-- <form class="flex justify-end mt-5" action="/" method="POST"> --}}
-                <form class="flex justify-end mt-5" action="{{ route('comment.store') }}" method="POST">
-                    @csrf
-                    <input type="hidden" name="post_id" value="{{ $post->id }}">
-                    {{-- <input class="border rounded px-2 flex-auto" type="text" name="reply_message"> --}}
-                    {{-- <input class="border rounded px-2 flex-initial" type="text" name="user_name" placeholder="UserName" required> --}}
-                    <input class="border rounded px-2 ml-2 flex-auto" type="text" name="message" placeholder="Comment" required>
-                    <input class="px-2 py-1 ml-2 rounded bg-green-600 text-white font-bold link-hover cursor-pointer"
-                        type="submit" value="返信">
-                    <input class="px-2 py-1 ml-2 rounded bg-red-500 text-white font-bold link-hover cursor-pointer"
-                        type="button" value="削除">
-                </form>
+                {{-- ボタン --}}
+                <div class="flex mt-5">
+                    {{-- 返信 --}}
+                    <form class="flex justify-end flex-auto" action="{{ route('comment.store') }}" method="POST">
+                        @csrf
+                        <input type="hidden" name="post_id" value="{{ $post->id }}">
+                        <input class="border rounded px-2 ml-2 flex-auto" type="text" name="message"
+                            placeholder="Comment" required>
+                        <input
+                            class="px-2 py-1 ml-2 rounded bg-green-600 text-white font-bold link-hover cursor-pointer"
+                            type="submit" value="返信">
+                    </form>
+                    {{-- 削除 --}}
+                    <form action="{{ route('posts.destroy', ['post' => $post->id]) }}" method="post">
+                        @csrf
+                        @method('DELETE')
+                        <input class="px-2 py-1 ml-2 rounded bg-red-500 text-white font-bold link-hover cursor-pointer"
+                            type="submit" value="削除" onclick="Check(event)">
+                    </form>
+                </div>
                 {{-- 返信 --}}
                 <hr class="mt-2 m-auto">
                 <div class="flex justify-end">
@@ -73,45 +80,6 @@
                     </div>
                 </div>
             </div>
-
-            {{-- 投稿 --}}
-            <div class="bg-white rounded-md mt-1 mb-1 p-3">
-                {{-- スレッド --}}
-                <div>
-                    <p class="mb-2 text-xs">2021/11/20 18:00 ＠Noname</p>
-                    <p class="mb-2 text-xl font-bold">●●について</p>
-                    <p class="mb-2">これは本文です。これは本文です。これは本文です。これは本文です。これは本文です。これは本文です。これは本文です。これは本文です。これは本文です。</p>
-                </div>
-                {{-- 削除ボタン --}}
-                <form class="flex justify-end mt-5" action="/" method="POST">
-                    @csrf
-                    <input class="border rounded px-2 flex-auto" type="text" name="reply_message">
-                    <input class="px-2 py-1 ml-2 rounded bg-green-600 text-white font-bold link-hover cursor-pointer"
-                        type="submit" value="返信">
-                    <input class="px-2 py-1 ml-2 rounded bg-red-500 text-white font-bold link-hover cursor-pointer"
-                        type="submit" value="削除">
-                </form>
-                {{-- 返信 --}}
-                <hr class="mt-2 m-auto">
-                <div class="flex justify-end">
-                    <div class="w-11/12">
-                        <div>
-                            <p class="mt-2 text-xs">2021/11/20 19:00 ＠Noname</p>
-                            <p class="my-2 text-sm">
-                                これは返信です。これは返信です。これは返信です。これは返信です。これは返信です。これは返信です。これは返信です。これは返信です。これは返信です。
-                            </p>
-                        </div>
-                        <hr class="mt-2 m-auto">
-                        <div>
-                            <p class="mt-2 text-xs">2021/11/20 19:00 ＠Noname</p>
-                            <p class="my-2 text-sm">
-                                これは返信です。これは返信です。これは返信です。これは返信です。これは返信です。これは返信です。これは返信です。これは返信です。これは返信です。
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
             {{-- ページネーション --}}
             <p class="flex justify-center text-blue-300 mt-1 mb-5 link-hover cursor-pointer">prev 1 2 3 4 next</p>
         @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,9 @@ Route::get('/index', [PostController::class, 'index'])
 Route::post('/posts', [PostController::class, 'store'])
     ->name('posts.store');
 
+Route::delete('/posts/{post}', [PostController::class, 'destroy'])
+    ->name('posts.destroy');
+
 Route::resource('/comment', CommentController::class);
 
 Route::get('/dashboard', function () {


### PR DESCRIPTION
## 目的
このプルリクエストでは、ユーザーが自分の投稿を削除できるようにすることで、ユーザー体験を向上させることを目的としています。

## 達成条件
- ユーザーは自分の投稿を削除できる。
- ユーザーは自分の投稿を削除する前に確認ダイアログを介して確認を求められる。
- 投稿が削除されたとき、関連するコメントもデータベースからカスケード削除される。

## 実装の概要
- `PostController`における`destroy`メソッドを実装し、指定された投稿IDの投稿を削除する機能を追加しました。
- 投稿テンプレートに返信および削除のためのフォームを追加し、削除ボタンを押すと確認ダイアログが表示されるようにしました。
- `comments`テーブルのマイグレーションを更新して、投稿が削除されたときに関連するコメントがカスケードで削除されるように変更しました。

## レビューしてほしいところ
- 追加した`destroy`メソッドの実装に関するフィードバック。
- フロントエンドの変更（特にJavaScriptの確認ダイアログの実装）に関するアドバイス。

## 不安に思っていること
- カスケード削除が正しく機能するかどうかについて、特にデータベースの外部キー制約の変更が適切に行われているかについて不安があります。