### PR TITLE
ページネーション機能の改善とデータ取得方法の最適化

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -14,7 +14,7 @@ class PostController extends Controller
      */
     public function index()
     {
-        $posts = Post::orderBy('created_at', 'desc')->get();
+        $posts = Post::orderBy('created_at', 'desc')->paginate(5); //データベースから5件ずつ取得されるように変更
         $comments = Comment::all();
         return view('layouts.index', compact('posts', 'comments'));
     }

--- a/resources/views/layouts/index.blade.php
+++ b/resources/views/layouts/index.blade.php
@@ -34,7 +34,7 @@
         </div>
 
         {{-- ページネーション --}}
-        <p class="flex justify-center text-blue-300 mt-5 link-hover cursor-pointer">prev 1 2 3 4 next</p>
+        <p class="mt-5">{{ $posts->links() }}</p>
 
         {{-- 投稿 --}}
         @foreach ($posts as $post)
@@ -81,7 +81,7 @@
                 </div>
             </div>
             {{-- ページネーション --}}
-            <p class="flex justify-center text-blue-300 mt-1 mb-5 link-hover cursor-pointer">prev 1 2 3 4 next</p>
         @endforeach
+        <p class="mt-5">{{ $posts->links() }}</p>
     </div>
 </x-app-layout>


### PR DESCRIPTION
## 目的

ウェブページのページネーション表示を動的にし、一度に表示される投稿の数を制限することで、ユーザーインターフェースの改善とパフォーマンスの向上を図る。

## 達成条件

- ページネーションが動的に表示されること。
- 各ページに投稿が5件ずつ表示されること。
- 全てのページで正確にページネーションが機能すること。

## 実装の概要

- `Post`モデルの取得方法を`get()`から`paginate(5)`に変更し、データベースからの投稿をページごとに5件ずつ取得するように変更しました。
- ビューでのページネーション表示を静的なテキストからLaravelの`links()`メソッドを使用した動的表示に変更しました。

## レビューしてほしいところ

- ページネーションの実装方法について、もっと効率的な書き方があれば提案をいただきたい。
- `paginate()`メソッドの使用に際して、特にパフォーマンスに影響を及ぼす可能性がある点についてのレビュー。

## 不安に思っていること

- 大量のデータがある場合にページネーションがスムーズに機能するかどうかが不安です。
- ユーザーが多い環境でのパフォーマンステストがまだ不十分であること。

## 保留していること

- 現在、全てのコメントを取得する処理 (`Comment::all()`) はそのままにしていますが、この部分もページネーションを考慮する必要がありそうです。
