### PR TITLE
投稿検索機能の追加とコメント関連のコード改善

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -74,4 +74,16 @@ class PostController extends Controller
        $Post = Post::find($id)->delete();
        return redirect('/index');
     }
+
+    public function search(Request $request)
+    {
+        $search_message = '%' .addcslashes($request->search_message, '%_\\') . '%';
+
+        $posts = Post::where('message', 'LIKE', $search_message)->orderBy('created_at', 'desc')->Paginate(5);
+
+        // 検索結果を表示するビューを返す
+        // compact関数は、指定された変数名に対応する変数の値を持つ連想配列を作成します。
+        // この場合、'posts'変数の値をビューに渡すために使用されています。
+        return view('layouts.index', compact('posts'));
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -19,7 +19,7 @@ class Post extends Model
         return $this->belongsTo(User::class, 'user_id');
     }
 
-    public function comment()
+    public function comments()
     {
         return $this->hasMany(Comment::class);
     }

--- a/resources/views/layouts/index.blade.php
+++ b/resources/views/layouts/index.blade.php
@@ -23,10 +23,10 @@
         </div>
         {{-- 検索フォーム --}}
         <div class="bg-white rounded-md mt-3 p-3">
-            <form action="/" method="post">
+            <form action="{{ route('posts.search')}}" method="post">
                 @csrf
                 <div class="mx-1 flex">
-                    <input class="border rounded px-2 flex-auto" type="text" name="serch_message">
+                    <input class="border rounded px-2 flex-auto" type="text" name="search_message" required>
                     <input class="ml-2 px-2 py-1 rounded bg-gray-500 text-white font-bold link-hover cursor-pointer"
                         type="submit" value="検索">
                 </div>
@@ -69,7 +69,7 @@
                 <hr class="mt-2 m-auto">
                 <div class="flex justify-end">
                     <div class="w-11/12">
-                        @foreach ($comments as $comment)
+                        @foreach ($post->comments as $comment)
                             <div>
                                 <p class="mt-2 text-xs">{{ $comment->created_at }} ＠{{ $comment->user->name }}</p>
                                 <p class="my-2 text-sm">

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,9 @@ Route::post('/posts', [PostController::class, 'store'])
 Route::delete('/posts/{post}', [PostController::class, 'destroy'])
     ->name('posts.destroy');
 
+Route::post('/posts/search', [PostController::class, 'search'])
+    ->name('posts.search');
+
 Route::resource('/comment', CommentController::class);
 
 Route::get('/dashboard', function () {


### PR DESCRIPTION
## 目的

- 投稿に対するコメントの取得方法を改善し、関連性を高める。
- 投稿の検索機能を追加し、ユーザーが容易に情報を見つけられるようにする。

## 達成条件

- 投稿に対して直接コメントを取得できるように`hasMany`リレーションを使用。
- 新しい検索フォームが正しく設定され、投稿をキーワードでフィルタリングできる。
- 検索結果がページネーションされ、5件ごとに表示される。

## 実装の概要

- `Post`モデルの`comment`メソッドを`comments`に変更し、`hasMany`リレーションを設定。
- ダッシュボードの検索フォームのアクションを修正し、入力フィールドに`required`属性を追加。
- `PostController`に`search`メソッドを追加し、入力されたキーワードに基づいて投稿を検索し、結果をビューに渡す。

## レビューしてほしいところ

- リレーションの定義変更が適切かどうか。
- 検索機能の実装に問題がないか、特にSQLインジェクションの防止策が正しく行われているか。

## 不安に思っていること

- 検索処理のパフォーマンスが大量のデータで試験されていない点。
- UIの変更が既存のユーザー体験に与える影響。

## 保留していること

- タイトルでの検索エンジンの導入は、この段階では行っていません。