### PR TITLE
ログインフォームのユーザー識別子の変更

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -47,6 +47,6 @@ class AuthenticatedSessionController extends Controller
 
     public function username(): string
     {
-        return 'username';
+        return 'username_id';
     }
 }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -31,13 +31,13 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            // 'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
+            'username_id' => ['required', 'string', 'max:255'],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
         $user = User::create([
             'name' => $request->name,
-            // 'email' => $request->email,
+            'username_id' => $request->username_id,
             'password' => Hash::make($request->password),
         ]);
 

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -31,13 +31,13 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
+            // 'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
         $user = User::create([
             'name' => $request->name,
-            'email' => $request->email,
+            // 'email' => $request->email,
             'password' => Hash::make($request->password),
         ]);
 

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -27,7 +27,7 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'username' => ['required', 'string'],
+            'username_id' => ['required', 'string'],
             'password' => ['required', 'string'],
         ];
     }
@@ -42,7 +42,7 @@ class LoginRequest extends FormRequest
         $this->ensureIsNotRateLimited(); // ログイン試行がレートリミットに達していないことを確認します。
 
         // ユーザー名とパスワードで認証を試みます。`remember`オプションがtrueの場合、セッションを永続化します。
-        if (! Auth::attempt($this->only('username', 'password'), $this->boolean('remember'))) {
+        if (! Auth::attempt($this->only('username_id', 'password'), $this->boolean('remember'))) {
             RateLimiter::hit($this->throttleKey()); // 認証に失敗した場合、レートリミットカウンターを増やします。
 
              // 認証に失敗したことをユーザーに通知します。エラーメッセージは`username`フィールドに関連付けられます。

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -20,7 +20,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
-        'username',
+        'username_id',
     ];
 
     /**

--- a/database/migrations/2024_04_15_081028_rename_user_id_to_username_id_in_users_table.php
+++ b/database/migrations/2024_04_15_081028_rename_user_id_to_username_id_in_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->renameColumn('user_id', 'username_id');
+        });
+    }
+
+    /**
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->renameColumn('username_id', 'user_id');
+        });
+    }
+};

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -138,5 +138,6 @@
     "results": "件",
     "to": "から",
     "Showing": "表示中：",
-    "Username": "ユーザー名"
+    "Username": "ユーザー名",
+    "Username ID": "ユーザーID"
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -5,12 +5,12 @@
     <form method="POST" action="{{ route('login') }}">
         @csrf
 
-        <!-- user name -->
+        <!-- id -->
         <div>
-            <x-input-label for="username" :value="__('Username')" />
-            <x-text-input id="username" class="block mt-1 w-full" type="text" name="username" :value="old('username')" required
-                autofocus autocomplete="username" />
-            <x-input-error :messages="$errors->get('username')" class="mt-2" />
+            <x-input-label for="username_id" :value="__('Username ID')" />
+            <x-text-input id="username_id" class="block mt-1 w-full" type="text" name="username_id" :value="old('username_id')" required
+                autofocus autocomplete="username_id" />
+            <x-input-error :messages="$errors->get('username_id')" class="mt-2" />
         </div>
 
         <!-- Password -->

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -10,11 +10,11 @@
         </div>
 
         <!-- Email Address -->
-        <div class="mt-4">
+        {{-- <div class="mt-4">
             <x-input-label for="email" :value="__('Email')" />
             <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autocomplete="username" />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
-        </div>
+        </div> --}}
 
         <!-- Password -->
         <div class="mt-4">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -9,6 +9,13 @@
             <x-input-error :messages="$errors->get('name')" class="mt-2" />
         </div>
 
+        {{-- Id --}}
+        <div class="mt-4">
+            <x-input-label for="username_id" :value="__('Username ID')" />
+            <x-text-input id="username_id" class="block mt-1 w-full" type="text" name="username_id" :value="old('username_id')" required autofocus autocomplete="username_id" />
+            <x-input-error :messages="$errors->get('username_id')" class="mt-2" />
+        </div>
+
         <!-- Email Address -->
         {{-- <div class="mt-4">
             <x-input-label for="email" :value="__('Email')" />

--- a/resources/views/components/auth-links.blade.php
+++ b/resources/views/components/auth-links.blade.php
@@ -10,12 +10,12 @@
                 class="inline-flex text-white bg-indigo-500 border-0 py-2 px-6 my-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">
                 ログイン
             </a>
-            {{-- @if (Route::has('register'))
+            @if (Route::has('register'))
                 <a href="{{ route('register') }}"
                     class="ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg">
                     新規登録
                 </a>
-            @endif --}}
+            @endif
         @endauth
     </nav>
 @endif


### PR DESCRIPTION
## 目的

ログインプロセスにおいてユーザー名のフィールドをユーザーIDに変更し、より直感的な識別を可能にするため。

## 達成条件

- ログインフォームがユーザーIDを使用していること。
- バックエンドがユーザーIDを認識して認証を試みること。
- 既存のテストが新しいフィールド名に対応し、問題なく動作すること。

## 実装の概要

- フォームのHTML部分で、`username`のラベルとフィールド名を`username_id`に変更。
- ログイン試行時の認証処理で、`username`の参照を`username_id`に更新。
- バリデーションルールと`username()`メソッドの返り値を`username_id`に変更。

## レビューしてほしいところ

- 変更した識別子の命名とその実装が適切かどうか。
- ログイン処理のセキュリティに影響がないかどうか。

## 不安に思っていること

- ユーザーIDへの変更が他のシステムやモジュールに潜在的な影響を及ぼすかどうか。
- 現行のテストケースではカバーしきれない新たなエッジケースが存在する可能性。