### PR TITLE
ユーザ登録フローの拡張とアクセス制御の初期段階の実装

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -41,10 +41,6 @@ class RegisteredUserController extends Controller
             'password' => Hash::make($request->password),
         ]);
 
-        event(new Registered($user));
-
-        Auth::login($user);
-
-        return redirect(route('dashboard', absolute: false));
+        return redirect(route('dashboard', absolute: false))->with('success', '新しいユーザーが正常に登録されました。');
     }
 }

--- a/resources/views/components/auth-links.blade.php
+++ b/resources/views/components/auth-links.blade.php
@@ -1,21 +1,6 @@
-{{-- @if (Route::has('login')) --}}
     <nav class="flex justify-center">
-        {{-- @auth
-            <a href="{{ url('/dashboard') }}"
-                class="rounded-md px-3 py-2 text-black ring-1 ring-transparent transition hover:text-black/70 focus:outline-none focus-visible:ring-[#FF2D20] dark:text-white dark:hover:text-white/80 dark:focus-visible:ring-white">
-                ダッシュボード
-            </a>
-        @else --}}
-            <a href="{{ route('login') }}"
-                class="inline-flex text-white bg-indigo-500 border-0 py-2 px-6 my-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">
-                ログイン
-            </a>
-            {{-- @if (Route::has('register'))
-                <a href="{{ route('register') }}"
-                    class="ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg">
-                    新規登録
-                </a>
-            @endif
-        @endauth --}}
+        <a href="{{ route('login') }}"
+            class="inline-flex text-white bg-indigo-500 border-0 py-2 px-6 my-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">
+            ログイン
+        </a>
     </nav>
-{{-- @endif --}}

--- a/resources/views/components/auth-links.blade.php
+++ b/resources/views/components/auth-links.blade.php
@@ -1,21 +1,21 @@
-@if (Route::has('login'))
+{{-- @if (Route::has('login')) --}}
     <nav class="flex justify-center">
-        @auth
+        {{-- @auth
             <a href="{{ url('/dashboard') }}"
                 class="rounded-md px-3 py-2 text-black ring-1 ring-transparent transition hover:text-black/70 focus:outline-none focus-visible:ring-[#FF2D20] dark:text-white dark:hover:text-white/80 dark:focus-visible:ring-white">
                 ダッシュボード
             </a>
-        @else
+        @else --}}
             <a href="{{ route('login') }}"
                 class="inline-flex text-white bg-indigo-500 border-0 py-2 px-6 my-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">
                 ログイン
             </a>
-            @if (Route::has('register'))
+            {{-- @if (Route::has('register'))
                 <a href="{{ route('register') }}"
                     class="ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg">
                     新規登録
                 </a>
             @endif
-        @endauth
+        @endauth --}}
     </nav>
-@endif
+{{-- @endif --}}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -14,10 +14,26 @@
             </div>
         </div>
     </div>
-    <div>
-        <a href="{{ route('register') }}"
-            class="ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg">
-            新規登録
-        </a>
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="flex items-center pr-6 py-6 text-gray-900">
+                    <div>
+                        <a href="{{ route('register') }}"
+                            class="ml-4 inline-flex text-white bg-indigo-500 border-0 py-2 px-6 focus:outline-none hover:bg-indigo-600 rounded text-lg">
+                            新規登録
+                        </a>
+                    </div>
+                    <div class="px-6">
+                        @if (session('success'))
+                            <div class="alert alert-success">
+                                {{ session('success') }}
+                            </div>
+                        @endif
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
+
 </x-app-layout>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -14,4 +14,10 @@
             </div>
         </div>
     </div>
+    <div>
+        <a href="{{ route('register') }}"
+            class="ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg">
+            新規登録
+        </a>
+    </div>
 </x-app-layout>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -11,11 +11,12 @@ use App\Http\Controllers\Auth\RegisteredUserController;
 use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware('guest')->group(function () {
-    Route::get('register', [RegisteredUserController::class, 'create'])
-                ->name('register');
+Route::get('register', [RegisteredUserController::class, 'create'])
+            ->name('register');
 
-    Route::post('register', [RegisteredUserController::class, 'store']);
+Route::post('register', [RegisteredUserController::class, 'store']);
+
+Route::middleware('guest')->group(function () {
 
     Route::get('login', [AuthenticatedSessionController::class, 'create'])
                 ->name('login');


### PR DESCRIPTION
## 目的

このプルリクエストでは、将来的に管理者のみが新規ユーザー登録を行えるようにする機能の基礎を築きます。最初のステップとして、ログイン済みのユーザー（将来的には管理者のみ）がダッシュボードから新規登録ページへアクセスできるように変更します。

## 達成条件

- ログイン済みのユーザーも新規登録ページにアクセスできるようにルーティングの変更を行います。
- ダッシュボードに新規登録のリンクが表示され、指定されたユーザーが新規登録画面に遷移できること。
- UIの更新が適切に行われ、新規登録関連のコンポーネントが適切に表示されること。

## 実装の概要

- `register` の GET と POST ルートを `guest` ミドルウェアグループから外し、ログインユーザーもアクセスできるようにしました。
- ダッシュボードに新規登録リンクを追加し、特定のユーザー（最終的には管理者のみ）が新規登録を行えるようにする準備をしました。
- コメントアウトされた条件式を削除し、コードの清潔さを保ちつつ、今後の拡張性を考慮しました。
- 新規登録後のリダイレクトに成功メッセージを追加し、ユーザーへのフィードバックを明確にしました。


## レビューしてほしいところ

- 新規登録ページへのアクセス制御が現在のユーザー基盤に適切かどうか、特にセキュリティ面での影響を検討していただきたいです。
- UIの変更が直感的で、ユーザーが容易に理解し、操作できるかどうかを確認してほしいです。

## 不安に思っていること

- アクセス制御の変更が意図したとおりに機能するかどうかが不安です。
- 今後、管理者権限の確立とその適用範囲の設定について、具体的な実装方針を詰める必要があります。

## 保留していること

- 管理者としてのアクセス制御を完全に実装する部分は、このプルリクエストでは対応しておらず、次のフェーズで行います。
