### PR TITLE
ユーザーとユニットテーブル更新

### DIFF
--- a/database/migrations/2024_04_22_210448_add_name_to_units_table.php
+++ b/database/migrations/2024_04_22_210448_add_name_to_units_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::table('units', function (Blueprint $table) {
+            $table->string('name'); // 'name'フィールドを追加
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('units', function (Blueprint $table) {
+            $table->dropColumn('name'); // ロールバック時に'name'フィールドを削除
+        });
+    }
+};

--- a/database/migrations/2024_04_22_211327_add_unit_id_to_users_tables.php.php
+++ b/database/migrations/2024_04_22_211327_add_unit_id_to_users_tables.php.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUnitIdToUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // unit_idカラムを追加し、unitsテーブルのidカラムとの外部キー制約を設定
+            $table->foreignId('unit_id')->nullable()->constrained('units')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // 外部キー制約を削除し、unit_idカラムを削除
+            $table->dropForeign(['unit_id']);
+            $table->dropColumn('unit_id');
+        });
+    }
+}
+


### PR DESCRIPTION
## 目的

- `users` テーブルに `unit_id` カラムを追加して、ユーザーとユニットの関連付けを強化する。
- `units` テーブルに `name` カラムを追加して、ユニット名を格納できるようにする。

## 達成条件

- `users` テーブルに `unit_id` カラムが追加され、nullを許容し、`units` テーブルの `id` カラムと外部キー制約が設定されること。
- 削除時にはカスケードで関連するデータが削除されること。
- `units` テーブルに `name` カラムが追加されること。

## 実装の概要

### `users` テーブルの変更

- `unit_id` カラムを追加し、外部キーとして `units.id` にリンク。
- `onDelete('cascade')` を用いて、ユニットが削除された際に関連するユーザー情報も自動で削除されるように設定。

### `units` テーブルの変更

- 新たに `name` カラムを追加し、ユニットの名前を格納。

## レビューしてほしいところ

- 外部キー制約の設定方法に問題がないか。
- `name` カラムのデータ型（現在はstring型を使用）について他に適切な型があるか。

## 不安に思っていること

- 外部キーのカスケード削除が適切に機能するかどうか。

## 保留していること

- `units` テーブルに他のカラムの追加は現時点では行わない。
