### PR TITLE
管理者登録と介護施設データの連携強化

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -36,7 +36,6 @@ class RegisteredUserController extends Controller
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ];
         
-
         // Check if the registration is for an administrator and require nursing home name
         if ($request->input('is_admin', false)) {
             $rules['nursing_home_name'] = ['required', 'string', 'max:255', 'unique:nursing_homes,name'];
@@ -44,17 +43,22 @@ class RegisteredUserController extends Controller
 
         $request->validate($rules);
 
+        // Create user
         $user = User::create([
             'name' => $request->name,
             'username_id' => $request->username_id,
             'password' => Hash::make($request->password),
         ]);
 
-        // If registering as an admin, create the nursing home record
+        // If registering as an admin, create the nursing home record and associate it
         if ($request->input('is_admin', false)) {
             $nursingHome = NursingHome::create([
                 'name' => $request->nursing_home_name,
             ]);
+
+            // Associate the user with the newly created nursing home
+            $user->nursing_home_id = $nursingHome->id;
+            $user->save();
         }
 
         Auth::login($user); // Log in the newly created user

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Models\NursingHome;
+use Spatie\Permission\Models\Role;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -37,7 +38,7 @@ class RegisteredUserController extends Controller
         ];
         
         // Check if the registration is for an administrator and require nursing home name
-        if ($request->input('is_admin', false)) {
+        if ($request->boolean('is_admin')) {  // Change to boolean check for clarity
             $rules['nursing_home_name'] = ['required', 'string', 'max:255', 'unique:nursing_homes,name'];
         }
 
@@ -51,7 +52,7 @@ class RegisteredUserController extends Controller
         ]);
 
         // If registering as an admin, create the nursing home record and associate it
-        if ($request->input('is_admin', false)) {
+        if ($request->boolean('is_admin')) {
             $nursingHome = NursingHome::create([
                 'name' => $request->nursing_home_name,
             ]);
@@ -59,6 +60,10 @@ class RegisteredUserController extends Controller
             // Associate the user with the newly created nursing home
             $user->nursing_home_id = $nursingHome->id;
             $user->save();
+
+            // Find the admin role and assign it to the user
+            $adminRole = Role::findByName('admin');
+            $user->assignRole($adminRole);
         }
 
         Auth::login($user); // Log in the newly created user

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -29,17 +29,26 @@ class RegisteredUserController extends Controller
      */
     public function store(Request $request): RedirectResponse
     {
-        $request->validate([
+        $rules = [
             'name' => ['required', 'string', 'max:255'],
             'username_id' => ['required', 'string', 'max:255'],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
-        ]);
+        ];
+
+        if ($request->input('is_admin', false)) {
+            $rules['nursing_home_name'] = ['required', 'string', 'max:255'];
+        }
+
+        $request->validate($rules);
 
         $user = User::create([
             'name' => $request->name,
             'username_id' => $request->username_id,
             'password' => Hash::make($request->password),
+            'nursing_home_name' => $request->nursing_home_name ?? null,
         ]);
+
+        Auth::login($user); // ユーザーをログイン状態にする
 
         return redirect(route('dashboard', absolute: false))->with('success', '新しいユーザーが正常に登録されました。');
     }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use App\Models\NursingHome;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -31,12 +32,14 @@ class RegisteredUserController extends Controller
     {
         $rules = [
             'name' => ['required', 'string', 'max:255'],
-            'username_id' => ['required', 'string', 'max:255'],
+            'username_id' => ['required', 'string', 'max:255', 'unique:users,username_id'],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ];
+        
 
+        // Check if the registration is for an administrator and require nursing home name
         if ($request->input('is_admin', false)) {
-            $rules['nursing_home_name'] = ['required', 'string', 'max:255'];
+            $rules['nursing_home_name'] = ['required', 'string', 'max:255', 'unique:nursing_homes,name'];
         }
 
         $request->validate($rules);
@@ -45,11 +48,17 @@ class RegisteredUserController extends Controller
             'name' => $request->name,
             'username_id' => $request->username_id,
             'password' => Hash::make($request->password),
-            'nursing_home_name' => $request->nursing_home_name ?? null,
         ]);
 
-        Auth::login($user); // ユーザーをログイン状態にする
+        // If registering as an admin, create the nursing home record
+        if ($request->input('is_admin', false)) {
+            $nursingHome = NursingHome::create([
+                'name' => $request->nursing_home_name,
+            ]);
+        }
 
-        return redirect(route('dashboard', absolute: false))->with('success', '新しいユーザーが正常に登録されました。');
+        Auth::login($user); // Log in the newly created user
+
+        return redirect(route('dashboard'))->with('success', '新しいユーザーが正常に登録されました。');
     }
 }

--- a/app/Models/NursingHome.php
+++ b/app/Models/NursingHome.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class NursingHome extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function users()
+    {
+        return $this->hasMany(User::class);
+    }
+
+}

--- a/app/Models/NursingHome.php
+++ b/app/Models/NursingHome.php
@@ -16,4 +16,8 @@ class NursingHome extends Model
         return $this->hasMany(User::class);
     }
 
+    public static function getNames()
+    {
+        return self::select('name')->get();
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
+use App\Models\NursingHome;
 
 class User extends Authenticatable
 {
@@ -46,4 +47,9 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function nursingHome()
+{
+    return $this->belongsTo(NursingHome::class);
+}
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\DB;
 use App\Models\NursingHome;
+use Illuminate\Support\Facades\Auth;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -23,7 +24,12 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         View::composer('*', function ($view) {
-            $view->with('nursingHomes', NursingHome::getNames());
+            if (Auth::check()) {
+                $nursingHome = Auth::user()->nursingHome;
+                $view->with('nursingHome', $nursingHome);
+            } else {
+                $view->with('nursingHome', null);
+            }
         });
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\DB;
+use App\Models\NursingHome;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -21,6 +22,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        View::composer('*', function ($view) {
+            $view->with('nursingHomes', NursingHome::getNames());
+        });
     }
 }

--- a/database/migrations/2024_05_09_091401_create_nursing_homes_table.php
+++ b/database/migrations/2024_05_09_091401_create_nursing_homes_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('nursing_homes', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('nursing_homes');
+    }
+};

--- a/database/migrations/2024_05_09_091516_add_nursing_home_id_to_users_table.php
+++ b/database/migrations/2024_05_09_091516_add_nursing_home_id_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('nursing_home_id')->nullable()->constrained('nursing_homes')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['nursing_home_id']);
+            $table->dropColumn('nursing_home_id');
+        });
+    }
+};

--- a/database/migrations/2024_05_10_074405_add_unique_constraint_to_name_on_nursing_homes.php
+++ b/database/migrations/2024_05_10_074405_add_unique_constraint_to_name_on_nursing_homes.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('nursing_homes', function (Blueprint $table) {
+            $table->string('name')->unique()->change();  // 既存のカラムにユニーク制約を追加
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('nursing_homes', function (Blueprint $table) {
+            $table->dropUnique(['name']);  // ユニーク制約を削除
+        });
+    }
+};
+

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -139,5 +139,7 @@
     "to": "から",
     "Showing": "表示中：",
     "Username": "ユーザー名",
-    "Username ID": "ユーザーID"
+    "Username ID": "ユーザーID",
+    "Nursing Home Name": "介護施設名",
+    "Register as administrator?": "管理者として登録する"
 }

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -255,6 +255,7 @@ return [
         'username' => 'ユーザー名',
         'year' => '年',
         'username_id' => 'ユーザーID',
+        'nursing_home_name' => '介護施設名',
     ],
 
 ];

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -254,6 +254,7 @@ return [
         'updated_at' => '更新日',
         'username' => 'ユーザー名',
         'year' => '年',
+        'username_id' => 'ユーザーID',
     ],
 
 ];

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -2,6 +2,7 @@
 import Alpine from "alpinejs";
 import "./bootstrap";
 import "./delete";
+import "./toggleNursingHomeInput";
 
 window.Alpine = Alpine;
 Alpine.start();

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -3,6 +3,7 @@ import Alpine from "alpinejs";
 import "./bootstrap";
 import "./delete";
 import "./toggleNursingHomeInput";
+import "./persistAdminCheckboxState";
 
 window.Alpine = Alpine;
 Alpine.start();

--- a/resources/js/persistAdminCheckboxState.js
+++ b/resources/js/persistAdminCheckboxState.js
@@ -1,0 +1,24 @@
+document.addEventListener("DOMContentLoaded", function () {
+    const adminCheckbox = document.getElementById("is_admin");
+    const container = document.getElementById("nursing_home_container");
+    const storedIsAdmin = localStorage.getItem("isAdmin");
+
+    // ローカルストレージから状態を取得し、チェックボックスに適用
+    if (storedIsAdmin === "true") {
+        adminCheckbox.checked = true;
+        container.style.display = "block";
+        document.getElementById("nursing_home_name").required = true;
+    } else {
+        adminCheckbox.checked = false;
+        container.style.display = "none";
+        document.getElementById("nursing_home_name").required = false;
+    }
+
+    // チェックボックスの変更を監視し、ローカルストレージに保存
+    adminCheckbox.addEventListener("change", function () {
+        localStorage.setItem("isAdmin", adminCheckbox.checked);
+        container.style.display = adminCheckbox.checked ? "block" : "none";
+        document.getElementById("nursing_home_name").required =
+            adminCheckbox.checked;
+    });
+});

--- a/resources/js/toggleNursingHomeInput.js
+++ b/resources/js/toggleNursingHomeInput.js
@@ -1,0 +1,11 @@
+document.addEventListener("DOMContentLoaded", function () {
+    const adminCheckbox = document.getElementById("is_admin");
+    if (adminCheckbox) {
+        adminCheckbox.addEventListener("change", function () {
+            const container = document.getElementById("nursing_home_container");
+            container.style.display = this.checked ? "block" : "none";
+            document.getElementById("nursing_home_name").required =
+                this.checked; // 施設名を必須にするかどうか
+        });
+    }
+});

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,12 +1,27 @@
 <x-guest-layout>
-    <form method="POST" action="{{ route('register') }}">
+    <form method="POST" action="{{ route('register') }}" id="registration-form">
         @csrf
 
-        <!-- Name -->
+        <!-- Admin Checkbox -->
         <div>
+            <x-input-label for="is_admin" :value="__('Register as administrator?')" />
+            <input type="checkbox" id="is_admin" name="is_admin"
+                class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+        </div>
+
+        <!-- Nursing Home Name -->
+        <div id="nursing_home_container" style="display: none;" class="mt-4">
+            <x-input-label for="nursing_home_name" :value="__('Nursing Home Name')" />
+            <x-text-input id="nursing_home_name" class="block mt-1 w-full" type="text" name="nursing_home_name"
+                :value="old('nursing_home_name')" autofocus autocomplete="nursing_home_name" />
+            <x-input-error :messages="$errors->get('nursing_home_name')" class="mt-2" />
+        </div>
+
+        <!-- Name -->
+        <div class="mt-4">
             <x-input-label for="name" :value="__('Name')" />
-            <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required
-                autofocus autocomplete="name" />
+            <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')"
+                required autofocus autocomplete="name" />
             <x-input-error :messages="$errors->get('name')" class="mt-2" />
         </div>
 
@@ -21,20 +36,16 @@
         <!-- Password -->
         <div class="mt-4">
             <x-input-label for="password" :value="__('Password')" />
-
             <x-text-input id="password" class="block mt-1 w-full" type="password" name="password" required
                 autocomplete="new-password" />
-
             <x-input-error :messages="$errors->get('password')" class="mt-2" />
         </div>
 
         <!-- Confirm Password -->
         <div class="mt-4">
             <x-input-label for="password_confirmation" :value="__('Confirm Password')" />
-
             <x-text-input id="password_confirmation" class="block mt-1 w-full" type="password"
                 name="password_confirmation" required autocomplete="new-password" />
-
             <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" />
         </div>
 

--- a/resources/views/layouts/index.blade.php
+++ b/resources/views/layouts/index.blade.php
@@ -88,9 +88,4 @@
         {{-- ページネーション --}}
         <p class="mt-5">{{ $posts->links() }}</p>
     </div>
-    <!-- Vue -->
-    <div id="app">
-        <unit-list-component></unit-list-component>
-        <router-view></router-view>
-    </div>
 </x-app-layout>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -20,6 +20,13 @@
                 </div>
             </div>
 
+
+            <div class="flex space-x-4">
+                @foreach ($nursingHomes as $nursingHome)
+                    <div>{{ $nursingHome->name }}</div>
+                @endforeach
+            </div>
+
             <!-- Settings Dropdown -->
             <div class="hidden sm:flex sm:items-center sm:ms-6">
                 <x-dropdown align="right" width="48">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -13,29 +13,35 @@
                 </div>
 
                 <!-- Navigation Links -->
-                <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
+                <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
                 </div>
             </div>
 
-
-            <div class="flex space-x-4">
-                @foreach ($nursingHomes as $nursingHome)
-                    <div>{{ $nursingHome->name }}</div>
-                @endforeach
-            </div>
+            <!-- Nursing Home Names -->
+            @if ($nursingHome)
+                <div
+                    class="flex items-center text-gray-500 hover:text-gray-700 bg-white px-3 py-2 text-sm font-medium rounded-md">
+                    {{ $nursingHome->name }}
+                </div>
+            @else
+                <div
+                    class="flex items-center text-gray-500 hover:text-gray-700 bg-white px-3 py-2 text-sm font-medium rounded-md">
+                    No Nursing Home associated.
+                </div>
+            @endif
 
             <!-- Settings Dropdown -->
-            <div class="hidden sm:flex sm:items-center sm:ms-6">
+            <div class="hidden sm:flex sm:items-center sm:ml-6">
                 <x-dropdown align="right" width="48">
                     <x-slot name="trigger">
                         <button
                             class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
                             <div>{{ Auth::user()->name }}</div>
 
-                            <div class="ms-1">
+                            <div class="ml-1">
                                 <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg"
                                     viewBox="0 0 20 20">
                                     <path fill-rule="evenodd"
@@ -66,7 +72,7 @@
             </div>
 
             <!-- Hamburger -->
-            <div class="-me-2 flex items-center sm:hidden">
+            <div class="-mr-2 flex items-center sm:hidden">
                 <button @click="open = ! open"
                     class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
                     <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,7 +5,6 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\UserController;
-use App\Http\Controllers\UnitController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -24,8 +23,6 @@ Route::post('/posts/search', [PostController::class, 'search'])
     ->name('posts.search');
 
 Route::resource('/comment', CommentController::class);
-
-Route::resource('/sidebar', UnitController::class);
 
 //users
 Route::get('/users', [UserController::class, 'index'])


### PR DESCRIPTION
## 目的

このプルリクエストでは、新規管理者の登録機能と介護施設データの連携を強化し、UIの改善とデータの整合性向上を目指します。また、アプリケーションのメンテナンス性を高めるために不要なコンポーネントの削除も含まれます。

## 達成条件

- 新規管理者が介護施設と関連付けられ、適切なロールが割り当てられること。
- 管理者登録時に介護施設名がユニークであることのバリデーションが適用されること。
- 不要なコードやコンポーネントが削除され、アプリケーションのクリーンアップが行われること。
- 全ビューで介護施設の名前が正しく表示されること。

## 実装の概要

- 管理者登録のロジックにおいて、新規介護施設の作成とユーザーとの関連付け、および自動ログインの処理を追加しました。
- ビュー内で認証ユーザーの関連施設を表示するロジックを改善し、施設がない場合は適切なメッセージが表示されるようにしました。
- ユーザー登録フォームに管理者チェックボックスと介護施設名入力フィールドを追加し、これらのフィールドの状態管理をローカルストレージで行う機能を実装しました。
- `username_id` のユニーク制約を追加し、介護施設名にもユニーク制約を設定しました。

## レビューしてほしいところ

- 新規管理者と介護施設のデータ連携に関するロジックの適切性。
- UI改善のためのJavaScriptの実装と、その他のフロントエンドの変更点。
- ユニーク制約の追加によるデータ整合性の強化についてのフィードバック。

## 不安に思っていること

- 新規導入されたバリデーションルールが予期せぬエラーを引き起こす可能性があるかどうか。
- ローカルストレージを利用した状態管理がブラウザ間で一貫性を持つかどうか。

## 保留していること

- UIのさらなる改善とユーザビリティテストは、フィードバックを得た後に検討します。
